### PR TITLE
minor fixes in RealTimeThread: delete copy constructor and set cpu latency

### DIFF
--- a/include/real_time_tools/thread.hpp
+++ b/include/real_time_tools/thread.hpp
@@ -117,8 +117,7 @@ namespace real_time_tools {
     bool block_memory_;
 
     /**
-     * @brief describes the optimization level of the CPU. this needs to be
-     * set to 0 to get proper realitime performance.
+     * @brief Optimization level of the CPU. Set to 0 to get proper real-time performance.
      * 
      */
     int cpu_dma_latency_;

--- a/include/real_time_tools/thread.hpp
+++ b/include/real_time_tools/thread.hpp
@@ -80,6 +80,7 @@ namespace real_time_tools {
       cpu_id_.clear();
       delay_ns_ = 0;
       block_memory_ = true;
+      cpu_dma_latency_ = 0;
     }
     /**
      * @brief Destroy the RealTimeThreadParameters object
@@ -114,6 +115,13 @@ namespace real_time_tools {
      * a non real time operation.
      */
     bool block_memory_;
+
+    /**
+     * @brief describes the optimization level of the CPU. this needs to be
+     * set to 0 to get proper realitime performance.
+     * 
+     */
+    int cpu_dma_latency_;
   };
 
 
@@ -130,10 +138,9 @@ namespace real_time_tools {
     RealTimeThread();
 
     /**
-     * @brief The copy constructor only "share the thread". It does not spawn
-     * another one.
+     * @brief We do not allow copies of this object
      */
-    RealTimeThread(const real_time_tools::RealTimeThread& other);
+    RealTimeThread(const real_time_tools::RealTimeThread& other) = delete;
 
     /**
      * @brief Destroy the RealTimeThread object.

--- a/src/thread.cpp
+++ b/src/thread.cpp
@@ -9,6 +9,7 @@
  */
 #include <stdexcept>
 #include "real_time_tools/thread.hpp"
+#include "real_time_tools/process_manager.hpp"
 
 namespace real_time_tools {
   RealTimeThread::RealTimeThread()
@@ -40,6 +41,11 @@ namespace real_time_tools {
     if (thread_ != nullptr)
     {
       printf("Thread already running");
+    }
+
+    if (parameters_.cpu_dma_latency_ >= 0)
+    {
+      set_cpu_dma_latency(parameters_.cpu_dma_latency_);
     }
 
     thread_.reset(new pthread_t());
@@ -224,17 +230,5 @@ namespace real_time_tools {
   }
 #endif // Defined NON_REAL_TIME
 
-  /**
-   * @brief Construct a new RealTimeThread::RealTimeThread object. It copies the
-   * paramters of the other thread but does *NOT* spwan a new one.
-   * Used by all os.
-   * 
-   * @param other 
-   */
-  RealTimeThread::RealTimeThread(const RealTimeThread& other)
-  {
-    thread_.reset(nullptr);
-    parameters_ = other.parameters_;
-  }
 
 } // namespace real_time_tools


### PR DESCRIPTION
 1 Deleted copy constructor of RealTimeThread class, since the old one had counterintuitive behavior. This means attempting to copy this class will give a compilation error which is much safer (and copying should not be necessary).

2 By default when creating a thread now we call set_cpu_dma_latency(0). This is necessary to make sure the thread runs in real-time.