### PR TITLE
Add CheckpointTimer to simplify time measurement in loops

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ add_real_time_tools_demo(demo_timing)
 add_real_time_tools_demo(demo_thread)
 # add_real_time_tools_demo(demo_segfault)
 add_real_time_tools_demo(demo_usb_stream_imu_3DM_GX3_25)
+add_real_time_tools_demo(demo_checkpoint_timer)
 
 ###############
 # EXECUTABLES #

--- a/demos/demo_checkpoint_timer.cpp
+++ b/demos/demo_checkpoint_timer.cpp
@@ -1,0 +1,65 @@
+/**
+ * @file
+ * @license BSD 3-clause
+ * @copyright Copyright (c) 2020, New York University and Max Planck
+ *            Gesellschaft
+ */
+/**
+ * @example demo_checkpoint_timer.cpp
+ * @brief Demo on how to use the CheckpointTimer.
+ *
+ * Note that when the statistics are printed like this, the printing is included
+ * in the time measurement of the total loop duration.
+ */
+
+#include <real_time_tools/checkpoint_timer.hpp>
+#include <real_time_tools/timer.hpp>
+
+
+//! @brief Dummy function
+void init()
+{
+    real_time_tools::Timer::sleep_ms(3);
+}
+//! @brief Dummy function
+void do_some_stuff()
+{
+    real_time_tools::Timer::sleep_ms(20);
+}
+//! @brief Dummy function
+void write_log()
+{
+    real_time_tools::Timer::sleep_ms(6);
+}
+
+//! @brief Simple example on how to use the CheckpointTimer in a loop.
+int main()
+{
+    //! [Usage of CheckpointTimer]
+
+    // set second template argument to false to disable timer
+    real_time_tools::CheckpointTimer<3, true> timer;
+
+    for (int i = 0; i < 1000; i++)
+    {
+        timer.start();
+
+        init();
+        timer.checkpoint("initialize");
+
+        do_some_stuff();
+        timer.checkpoint("do some stuff");
+
+        write_log();
+        timer.checkpoint("logging");
+
+        // print the timing results every 100 iterations
+        if (i % 100 == 0 && i > 0)
+        {
+            timer.print_statistics();
+        }
+    }
+
+    //! [Usage of CheckpointTimer]
+    return 0;
+}

--- a/include/real_time_tools/checkpoint_timer.hpp
+++ b/include/real_time_tools/checkpoint_timer.hpp
@@ -1,0 +1,86 @@
+/**
+ * @file
+ * @license BSD 3-clause
+ * @copyright Copyright (c) 2020, New York University and Max Planck
+ *            Gesellschaft
+ *
+ * @brief Implementation of the CheckpointTimer class.
+ */
+
+#pragma once
+
+#include <array>
+#include <iostream>
+#include <string>
+
+#include "timer.hpp"
+
+namespace real_time_tools
+{
+/**
+ * @brief Timer to measure code execution time with "checkpoints"
+ *
+ * This timer is meant to be used for measuring execution time of a loop.  It
+ * measures time between calls of the `start` method, so by calling this at the
+ * beginning of the loop, you get the execution time of the full iteration.
+ * Further, you can define "checkpoints" within the loop to measure time of
+ * separate steps in the loop.  Call the `checkpoint` method after the code that
+ * is associated with it.  For each checkpoint, the time elapsed since the last
+ * checkpoint is measured (`start` counts as a checkpoint in this regard).
+ *
+ * Example:
+ *
+ * ~~~{.cpp}
+ * CheckpointTimer<3> timer;
+ *
+ * while (condition)
+ * {
+ *     timer.start();
+ *
+ *     initialize()
+ *     timer.checkpoint("initialize");
+ *
+ *     do();
+ *     some();
+ *     stuff();
+ *     timer.checkpoint("do some stuff");
+ *
+ *     write_log();
+ *     timer.checkpoint("logging");
+ * }
+ * ~~~
+ *
+ * @tparam NUM_CHECKPOINTS Number of checkpoints.
+ * @tparam ENABLED Set to false, to disable timer.  Method calls will have no
+ * effect (and should hopefully be optimized away by the compiler).
+ */
+template <size_t NUM_CHECKPOINTS, bool ENABLED = true>
+class CheckpointTimer
+{
+public:
+    CheckpointTimer();
+
+    //! @brief Start timer iteration.
+    void start();
+
+    /**
+     * @brief Set checkpoint for time measurement.
+     *
+     * Measures time from the last call of start() or checkpoint() until this
+     * call.  The given name is used when printing the results.
+     *
+     * @param checkpoint_name Name of the checkpoint (used for printing results)
+     */
+    void checkpoint(const std::string &checkpoint_name);
+
+    //! @brief Print results of time measurements.
+    void print_statistics() const;
+
+private:
+    std::array<real_time_tools::Timer, NUM_CHECKPOINTS + 1> timers_;
+    std::array<std::string, NUM_CHECKPOINTS + 1> checkpoint_names_;
+    size_t current_checkpoint = 1;
+};
+
+#include "checkpoint_timer.hxx"
+}  // namespace real_time_tools

--- a/include/real_time_tools/checkpoint_timer.hpp
+++ b/include/real_time_tools/checkpoint_timer.hpp
@@ -77,9 +77,13 @@ public:
     void print_statistics() const;
 
 private:
+    //! @brief Timers used for the different checkpoints.  Index 0 is used for
+    //!        the total duration.
     std::array<real_time_tools::Timer, NUM_CHECKPOINTS + 1> timers_;
+    //! @brief Names of the checkpoints.
     std::array<std::string, NUM_CHECKPOINTS + 1> checkpoint_names_;
-    size_t current_checkpoint = 1;
+    //! @brief Index of the current checkpoint.
+    size_t current_checkpoint_ = 1;
 };
 
 #include "checkpoint_timer.hxx"

--- a/include/real_time_tools/checkpoint_timer.hpp
+++ b/include/real_time_tools/checkpoint_timer.hpp
@@ -29,26 +29,7 @@ namespace real_time_tools
  * checkpoint is measured (`start` counts as a checkpoint in this regard).
  *
  * Example:
- *
- * ~~~{.cpp}
- * CheckpointTimer<3> timer;
- *
- * while (condition)
- * {
- *     timer.start();
- *
- *     initialize()
- *     timer.checkpoint("initialize");
- *
- *     do();
- *     some();
- *     stuff();
- *     timer.checkpoint("do some stuff");
- *
- *     write_log();
- *     timer.checkpoint("logging");
- * }
- * ~~~
+ * @snippet demo_checkpoint_timer.cpp Usage of CheckpointTimer
  *
  * @tparam NUM_CHECKPOINTS Number of checkpoints.
  * @tparam ENABLED Set to false, to disable timer.  Method calls will have no

--- a/include/real_time_tools/checkpoint_timer.hxx
+++ b/include/real_time_tools/checkpoint_timer.hxx
@@ -1,0 +1,68 @@
+/**
+ * @file
+ * @license BSD 3-clause
+ * @copyright Copyright (c) 2020, New York University and Max Planck
+ *            Gesellschaft
+ *
+ * @brief Implementation of the CheckpointTimer class.
+ */
+
+template <size_t NUM_CHECKPOINTS, bool ENABLED>
+CheckpointTimer<NUM_CHECKPOINTS, ENABLED>::CheckpointTimer()
+{
+    static_assert(NUM_CHECKPOINTS > 0,
+                  "CheckpointTimer needs at least one checkpoint");
+    checkpoint_names_[0] = "Total";
+}
+
+template <size_t NUM_CHECKPOINTS, bool ENABLED>
+void CheckpointTimer<NUM_CHECKPOINTS, ENABLED>::start()
+{
+    if (ENABLED)
+    {
+        timers_[0].tac_tic();
+        current_checkpoint = 1;
+        timers_[current_checkpoint].tic();
+    }
+}
+
+template <size_t NUM_CHECKPOINTS, bool ENABLED>
+void CheckpointTimer<NUM_CHECKPOINTS, ENABLED>::checkpoint(
+    const std::string &checkpoint_name)
+{
+    if (ENABLED)
+    {
+        timers_[current_checkpoint].tac();
+
+        if (checkpoint_names_[current_checkpoint].empty())
+        {
+            checkpoint_names_[current_checkpoint] = checkpoint_name;
+        }
+        else if (checkpoint_names_[current_checkpoint] != checkpoint_name)
+        {
+            throw std::runtime_error("Wrong checkpoint called (expected '" +
+                                     checkpoint_names_[current_checkpoint] +
+                                     "' but got '" + checkpoint_name + "').");
+        }
+
+        current_checkpoint++;
+        if (current_checkpoint < timers_.size())
+        {
+            timers_[current_checkpoint].tic();
+        }
+    }
+}
+
+template <size_t NUM_CHECKPOINTS, bool ENABLED>
+void CheckpointTimer<NUM_CHECKPOINTS, ENABLED>::print_statistics() const
+{
+    if (ENABLED)
+    {
+        std::cout << "======================================" << std::endl;
+        for (size_t i = 0; i < timers_.size(); i++)
+        {
+            std::cout << "===== " << checkpoint_names_[i] << std::endl;
+            timers_[i].print_statistics();
+        }
+    }
+}

--- a/include/real_time_tools/checkpoint_timer.hxx
+++ b/include/real_time_tools/checkpoint_timer.hxx
@@ -21,8 +21,8 @@ void CheckpointTimer<NUM_CHECKPOINTS, ENABLED>::start()
     if (ENABLED)
     {
         timers_[0].tac_tic();
-        current_checkpoint = 1;
-        timers_[current_checkpoint].tic();
+        current_checkpoint_ = 1;
+        timers_[current_checkpoint_].tic();
     }
 }
 
@@ -32,23 +32,23 @@ void CheckpointTimer<NUM_CHECKPOINTS, ENABLED>::checkpoint(
 {
     if (ENABLED)
     {
-        timers_[current_checkpoint].tac();
+        timers_[current_checkpoint_].tac();
 
-        if (checkpoint_names_[current_checkpoint].empty())
+        if (checkpoint_names_[current_checkpoint_].empty())
         {
-            checkpoint_names_[current_checkpoint] = checkpoint_name;
+            checkpoint_names_[current_checkpoint_] = checkpoint_name;
         }
-        else if (checkpoint_names_[current_checkpoint] != checkpoint_name)
+        else if (checkpoint_names_[current_checkpoint_] != checkpoint_name)
         {
             throw std::runtime_error("Wrong checkpoint called (expected '" +
-                                     checkpoint_names_[current_checkpoint] +
+                                     checkpoint_names_[current_checkpoint_] +
                                      "' but got '" + checkpoint_name + "').");
         }
 
-        current_checkpoint++;
-        if (current_checkpoint < timers_.size())
+        current_checkpoint_++;
+        if (current_checkpoint_ < timers_.size())
         {
-            timers_[current_checkpoint].tic();
+            timers_[current_checkpoint_].tic();
         }
     }
 }


### PR DESCRIPTION
# Description
The `CheckpointTimer` class is intended for time measurement of loops
where the time spent in separate sections of the code is measured, as
well as the total duration of the loop.  See doxygen of the class for
more details.

It is basically a wrapper around a list of `Timer` instances with the
purpose to not clutter the measured code too much.  Also it can easily
be disabled via a template argument which should result in the compiler
optimizing away the function calls completely (i.e. no need to have
commented lines in the code).

# How I Tested
By using it in robot_interfaces::RobotBackend (see https://github.com/open-dynamic-robot-initiative/robot_interfaces/pull/34).