### PR TITLE
fix the mutex class in rt_preempt

### DIFF
--- a/include/real_time_tools/mutex.hpp
+++ b/include/real_time_tools/mutex.hpp
@@ -11,6 +11,8 @@
 #ifndef MUTEX_HPP
 #define MUTEX_HPP
 
+#include <string>
+
 #if defined(XENOMAI)
   #include <native/mutex.h>
   #include <native/cond.h>
@@ -55,7 +57,7 @@ public:
    */
   RealTimeMutex(std::string mutex_id="")
   {
-
+    mutex_id_ = mutex_id;
 
     int res = 0;
 #if defined(XENOMAI)
@@ -144,6 +146,11 @@ private:
    * is compiled
    */
   RealTimeMutex_t mutex_;
+
+  /**
+   * @brief Save the mutex id internally.
+   */
+  std::string mutex_id_;
 };
 
 } // namespace


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Fix a small bug in the compilation of the rt_mutex on rt_preempt.

[//]: # "Description of what you did.  If it is more complex, consider to add a"
[//]: # "'Summary' section."


## How I Tested

[//]: # "Explain how you tested your changes"

Use it in one of the dependence package (dg_reactive_planners).

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
