### PR TITLE
Mark time series as deprecated

### DIFF
--- a/include/real_time_tools/threadsafe/threadsafe_timeseries.hpp
+++ b/include/real_time_tools/threadsafe/threadsafe_timeseries.hpp
@@ -33,9 +33,11 @@ namespace real_time_tools
  * newest\} \f$,
  * - a length \f$length\f$
  * - and a maximum length \f$maxlength\f$
+ *
+ * \deprecated Use the implementation from the time_series package instead.
  */
 template <typename Type = int>
-class ThreadsafeTimeseries
+class [[deprecated]] ThreadsafeTimeseries
 {
 public:
     /**


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description
The `ThreadsafeTimeseries` is deprecated and should not be used anymore
(there is a new implementation in a separate package called
"time_series").  Mark the class as deprecated so there will be compile
time warnings when it is used.

~As the `[[deprecated]]` attribute was added in C++14, increase the used
standard from 11 to 14.~

~**Is the change to C++14 okay or could this cause compatibility issues somewhere?**  I tested with Ubuntu 16.04 and there it seems to be fine.~

## How I Tested
Compiled and verified that deprecation warnings are shown.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
