### PR TITLE
reread the data

### DIFF
--- a/include/real_time_tools/usb_stream.hpp
+++ b/include/real_time_tools/usb_stream.hpp
@@ -123,7 +123,7 @@ public:
     bool close_device();
 
     /**
-     * @brief Read the port or the file.
+     * @brief Read the port or the file. Reports error if read bytes is not equal to expected bytes.
      *
      * @param msg is the command sent before this command was executed.
      * @param stream_on define if we just read on the fly or we wait until we
@@ -132,6 +132,20 @@ public:
      * @return false
      */
     bool read_device(std::vector<uint8_t>& msg, const bool stream_on = true);
+
+    /**
+     * @brief Read the port or the file. Does not check if read bytes is equal to expected bytes.
+     *
+     * @param msg is the command sent before this command was executed.
+     * @param stream_on define if we just read on the fly or we wait until we
+     * get the correct amount of data.
+     * @param start_location is the index in msg that we want to start reading to. 
+     * This is for when you want to keep a portion of the already existing data:
+     * For example, when you are have read a partial message and need to get the rest
+     * while keeping the first part.
+     * @return Number of bytes read or -1 if failure.
+     */
+    ssize_t read_maybe_device(std::vector<uint8_t>& msg, const bool stream_on = true, const size_t start_location = 0);
 
     /**
      * @brief Write msg in the port or the file.

--- a/include/real_time_tools/usb_stream.hpp
+++ b/include/real_time_tools/usb_stream.hpp
@@ -145,7 +145,7 @@ public:
      * while keeping the first part.
      * @return Number of bytes read or -1 if failure.
      */
-    ssize_t read_maybe_device(std::vector<uint8_t>& msg, const bool stream_on = true, const size_t start_location = 0);
+    ssize_t read_device_raw(std::vector<uint8_t>& msg, const bool stream_on = true, const size_t start_location = 0);
 
     /**
      * @brief Write msg in the port or the file.

--- a/src/usb_stream.cpp
+++ b/src/usb_stream.cpp
@@ -385,7 +385,7 @@ bool UsbStream::read_device(std::vector<uint8_t>& msg, const bool stream_on)
                                 &timeout_posix_,  // timeout
                                 nullptr);         // sigmask
 
-        // an error occured during the ressource access
+        // an error occured during the resource access
         if (return_value_ == -1)
         {
             int errsv = errno;
@@ -420,6 +420,10 @@ bool UsbStream::read_device(std::vector<uint8_t>& msg, const bool stream_on)
     else
     {
         return_value_ = read(file_id_, buffer_.data(), msg.size());
+        // try to read again if bytes requested != bytes received 
+        if (return_value_ != static_cast<ssize_t>(msg.size())){  // changed
+            return_value_ += read(file_id_, buffer_.data()+return_value_, msg.size()-return_value_);
+        }
     }
 #endif
     /**

--- a/src/usb_stream.cpp
+++ b/src/usb_stream.cpp
@@ -351,7 +351,7 @@ bool UsbStream::close_device()
 bool UsbStream::read_device(std::vector<uint8_t>& msg, const bool stream_on)
 {
     // read device and then store number of bytes read
-    return_value_ = UsbStream::read_maybe_device(msg, stream_on);
+    return_value_ = UsbStream::read_device_raw(msg, stream_on);
     /**
      * Check the potential error:
      *
@@ -390,10 +390,10 @@ bool UsbStream::read_device(std::vector<uint8_t>& msg, const bool stream_on)
     return true;
 }
 
-ssize_t UsbStream::read_maybe_device(std::vector<uint8_t>& msg, const bool stream_on, const size_t start_location)
+ssize_t UsbStream::read_device_raw(std::vector<uint8_t>& msg, const bool stream_on, const size_t start_location)
 {
     // We make sure that the internal buffer is big enough, while avoiding too
-    // many resize. Theoretically the default size is good enough.
+    // many resizes. Theoretically the default size is good enough.
     if (msg.size() - start_location > buffer_.size())
     {
         rt_printf(

--- a/src/usb_stream.cpp
+++ b/src/usb_stream.cpp
@@ -357,7 +357,7 @@ bool UsbStream::read_device(std::vector<uint8_t>& msg, const bool stream_on)
      *
      * - First we check if the port could be read at all.
      * - Then we check if the port was read before the timeout
-     * - Then we check the validity of the message FIXME where is validity checking?
+     * - Then we check the validity of the message
      */
 
     // Port reading failure

--- a/src/usb_stream.cpp
+++ b/src/usb_stream.cpp
@@ -421,8 +421,8 @@ bool UsbStream::read_device(std::vector<uint8_t>& msg, const bool stream_on)
     {
         return_value_ = read(file_id_, buffer_.data(), msg.size());
         // try to read again if bytes requested != bytes received 
-        if (return_value_ != static_cast<ssize_t>(msg.size())){  // changed
-            return_value_ += read(file_id_, buffer_.data()+return_value_, msg.size()-return_value_);
+        if (return_value_ != static_cast<ssize_t>(msg.size())){
+            return_value_ += read(file_id_, buffer_.data() + return_value_, msg.size() - return_value_);
         }
     }
 #endif


### PR DESCRIPTION
When using the python bindings (pybind11) for the imu (IMU3DM_GX3_25, located in imu_core) with the test file (located in the tests folder of imu_core), the usb_stream.cpp file has errors where it doesn't read enough bytes (prints error at line ~451), which also causes subsequent data readings to be misaligned. This causes the imu to not be able to read acceleration/angular rate because it doesn't get past the setup phase. The edit forces the rereading of the rest of the data so that it receives the expected number of byte and no longer causes the rest of the data to be misaligned.