### PR TITLE
remove unclear comment

### DIFF
--- a/src/usb_stream.cpp
+++ b/src/usb_stream.cpp
@@ -357,7 +357,6 @@ bool UsbStream::read_device(std::vector<uint8_t>& msg, const bool stream_on)
      *
      * - First we check if the port could be read at all.
      * - Then we check if the port was read before the timeout
-     * - Then we check the validity of the message
      */
 
     // Port reading failure


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

[//]: # "Description of what you did.  If it is more complex, consider to add a"
[//]: # "'Summary' section."
The comment describe 3 sections: port reading, port timeout, and message validity. The code only has port reading at L363 and port timeout at L374. Within this contiguous code chunk, I don't see anything that checks the validity of the message. I think we should remove the 3rd section, or otherwise explain where the validity checking occurs.
