### PR TITLE
Bump version to 3.0.0 and add changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+
+
+## [Unreleased]
+
+## [3.0.0] - 2022-06-29
+### Added
+- Extend `FrequencyManager` API.
+
+### Changed
+- Remove sleep in `UsbStream::close_device`.
+- Changes in `UsbStream` (#31).
+
+### Removed
+- ThreadsafeTimeseries (use the time_series package instead).
+
+### Fixed
+- Make the package compile on macOS.
+
+
+## [2.0.0] - 2021-03-02
+
+There is no changelog for this or earlier versions.
+
+
+[Unreleased]: https://github.com/machines-in-motion/real_time_tools/compare/v3.0.0...HEAD
+[3.0.0]: https://github.com/machines-in-motion/real_time_tools/compare/v2.0.0...v3.0.0
+[2.0.0]: https://github.com/machines-in-motion/real_time_tools/releases/tag/v2.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Remove sleep in `UsbStream::close_device`.
-- Changes in `UsbStream` (#31).
+- Add safety checks during the reading of serial port (usb) messages (#31).
 
 ### Removed
 - ThreadsafeTimeseries (use the time_series package instead).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 #
 cmake_minimum_required(VERSION 3.10.2)
 
-project(real_time_tools VERSION 2.0.0)
+project(real_time_tools VERSION 3.0.0)
 
 # Using C++17
 if(NOT CMAKE_C_STANDARD)


### PR DESCRIPTION
## Description
Bump version to 3.0.0 and add a changelog (following the format suggested by https://keepachangelog.com/en/1.0.0/).

In preparation for the upcoming Real Robot Challenge 2022, I'm making versioned releases of our packages and use the occasion to add proper changelog files.

@jviereck @MaximilienNaveau:  It would be great if you could give a brief summary of what was changed in #31 (just "Changes in `UsbStream`" is not very useful^^).