### PR TITLE
CheckpointTimer: Use string_view instead of string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
 ## [Unreleased]
+### Changed
+- CheckpointTimer: Use `string_view` instead of `string` for checkpoints names.
+  This avoids dynamic memory allocation for the strings and thus makes it more
+  suitable for real-time critical applications.
 
 ## [3.0.0] - 2022-06-29
 ### Added

--- a/include/real_time_tools/checkpoint_timer.hpp
+++ b/include/real_time_tools/checkpoint_timer.hpp
@@ -11,7 +11,7 @@
 
 #include <array>
 #include <iostream>
-#include <string>
+#include <string_view>
 
 #include "timer.hpp"
 
@@ -52,7 +52,7 @@ public:
      *
      * @param checkpoint_name Name of the checkpoint (used for printing results)
      */
-    void checkpoint(const std::string &checkpoint_name);
+    void checkpoint(std::string_view checkpoint_name);
 
     //! @brief Print results of time measurements.
     void print_statistics() const;
@@ -62,7 +62,7 @@ private:
     //!        the total duration.
     std::array<real_time_tools::Timer, NUM_CHECKPOINTS + 1> timers_;
     //! @brief Names of the checkpoints.
-    std::array<std::string, NUM_CHECKPOINTS + 1> checkpoint_names_;
+    std::array<std::string_view, NUM_CHECKPOINTS + 1> checkpoint_names_;
     //! @brief Index of the current checkpoint.
     size_t current_checkpoint_ = 1;
 };

--- a/include/real_time_tools/checkpoint_timer.hxx
+++ b/include/real_time_tools/checkpoint_timer.hxx
@@ -6,6 +6,7 @@
  *
  * @brief Implementation of the CheckpointTimer class.
  */
+#include <string>
 
 template <size_t NUM_CHECKPOINTS, bool ENABLED>
 CheckpointTimer<NUM_CHECKPOINTS, ENABLED>::CheckpointTimer()
@@ -28,7 +29,7 @@ void CheckpointTimer<NUM_CHECKPOINTS, ENABLED>::start()
 
 template <size_t NUM_CHECKPOINTS, bool ENABLED>
 void CheckpointTimer<NUM_CHECKPOINTS, ENABLED>::checkpoint(
-    const std::string &checkpoint_name)
+    std::string_view checkpoint_name)
 {
     if (ENABLED)
     {
@@ -40,9 +41,10 @@ void CheckpointTimer<NUM_CHECKPOINTS, ENABLED>::checkpoint(
         }
         else if (checkpoint_names_[current_checkpoint_] != checkpoint_name)
         {
-            throw std::runtime_error("Wrong checkpoint called (expected '" +
-                                     checkpoint_names_[current_checkpoint_] +
-                                     "' but got '" + checkpoint_name + "').");
+            throw std::runtime_error(
+                "Wrong checkpoint called (expected '" +
+                std::string(checkpoint_names_[current_checkpoint_]) +
+                "' but got '" + std::string(checkpoint_name) + "').");
         }
 
         current_checkpoint_++;


### PR DESCRIPTION

[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Avoids dynamic memory allocation for creating the strings and is thus more suitable for use in real-time critical code.



## How I Tested

Ran some code using it to verify that it builds and checkpoint names are properly displayed.
